### PR TITLE
Implement send-side throttling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,7 @@ strip = true
 
 [dev-dependencies]
 tempfile = "3.11.0"
+
+[lib]
+name = "ratelimiter"
+path = "src/ratelimiter.rs"

--- a/src/main.rs
+++ b/src/main.rs
@@ -384,7 +384,9 @@ fn main_send(
                     if let Some(ref mut ratelimiter) = opt_ratelimiter {
                         let to_wait =
                             ratelimiter.time_until_bytes_available(Instant::now(), MAX_CHUNK_LEN);
-                        std::thread::sleep(to_wait);
+                        // if to_wait is None, we've requested to send more than the bucket's max
+                        // capacity, which is a programming error. Crash the program.
+                        std::thread::sleep(to_wait.unwrap());
                     }
                     match file.send_one(start_time, &mut stream) {
                         Ok(SendResult::Progress {

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,29 +31,29 @@ Usage:
   fastsync recv <server-addr> <num-streams>
 
 Sender options:
-  <listen-addr>             Address (IP and port) for the sending side to bind to and
-                            listen for receivers. This should be the address of a
-                            Wireguard interface if you care about confidentiality.
-                            E.g. '100.71.154.83:7999'.
+  <listen-addr>                  Address (IP and port) for the sending side to bind to and
+                                 listen for receivers. This should be the address of a
+                                 Wireguard interface if you care about confidentiality.
+                                 E.g. '100.71.154.83:7999'.
 
-  [--max-bandwidth <MBps>]  Specify the maximum bandwidth to use over a 1 second sliding
-                            window, in MB/s. If unspecified, there will be no limit.
+  [--max-bandwidth-mbps <MBps>]  Specify the maximum bandwidth to use over a 1 second sliding
+                                 window, in MB/s. If unspecified, there will be no limit.
 
-  <in-files...>             Paths of files to send. Input file paths need to be relative.
-                            This is a safety measure to make it harder to accidentally
-                            overwrite files in /etc and the like on the receiving end.
+  <in-files...>                  Paths of files to send. Input file paths need to be relative.
+                                 This is a safety measure to make it harder to accidentally
+                                 overwrite files in /etc and the like on the receiving end.
 
 Receiver options:
-  <server-addr>             The address (IP and port) that the sender is listening on.
-                            E.g. '100.71.154.83:7999'.
+  <server-addr>                  The address (IP and port) that the sender is listening on.
+                                 E.g. '100.71.154.83:7999'.
 
-  <num-streams>             The number of TCP streams to open. For a value of 1, Fastsync
-                            behaves very similar to 'netcat'. With higher values,
-                            Fastsync leverages the fact that file chunks don't need to
-                            arrive in order to avoid the head-of-line blocking of a
-                            single connection. You should experiment to find the best
-                            value, going from 1 to 4 is usually helpful, going from 16
-                            to 32 is probably overkill.
+  <num-streams>                  The number of TCP streams to open. For a value of 1, Fastsync
+                                 behaves very similar to 'netcat'. With higher values,
+                                 Fastsync leverages the fact that file chunks don't need to
+                                 arrive in order to avoid the head-of-line blocking of a
+                                 single connection. You should experiment to find the best
+                                 value, going from 1 to 4 is usually helpful, going from 16
+                                 to 32 is probably overkill.
 ";
 
 const WIRE_PROTO_VERSION: u16 = 1;
@@ -141,10 +141,10 @@ fn main() {
         Some("send") if args.len() >= 3 => {
             let addr = &args[1];
             let max_bandwidth = match args[2].as_str() {
-                "--max-bandwidth" => Some(
+                "--max-bandwidth-mbps" => Some(
                     args[3]
                         .parse::<u64>()
-                        .expect("Invalid number for --max-bandwidth"),
+                        .expect("Invalid number for --max-bandwidth-mbps"),
                 ),
                 _ => None,
             };

--- a/src/main.rs
+++ b/src/main.rs
@@ -342,7 +342,7 @@ fn main_send(
     let limiter_mutex = Arc::new(Mutex::new(Option::<RateLimiter>::None));
 
     if let Some(mbps) = max_bandwidth_mbps {
-        let ratelimiter = RateLimiter::new(mbps, Instant::now());
+        let ratelimiter = RateLimiter::new(mbps, MAX_CHUNK_LEN, Instant::now());
         _ = limiter_mutex.lock().unwrap().insert(ratelimiter);
     }
 

--- a/src/ratelimiter.rs
+++ b/src/ratelimiter.rs
@@ -1,45 +1,140 @@
-use std::thread::sleep;
 use std::time::{Duration, Instant};
 
 #[derive(Debug)]
 pub struct RateLimiter {
-    available_tokens: f32,
-    tokens_per_second: f32,
+    available_bytes: u64,
+    bytes_per_second: u64,
     last_update: Instant,
 }
 
 impl RateLimiter {
-    pub(crate) fn new(chunk_size_bytes: u64, mbps_target: Option<u64>) -> Self {
-        let bps_target = mbps_target.map(|x| x * 1_000_000);
-        let tokens_per_second = match bps_target {
-            None => 0.0,
-            Some(bps) => bps as f32 / chunk_size_bytes as f32,
-        };
+    pub fn new(mbps_target: u64, now: Instant) -> Self {
+        let bps_target = mbps_target * 1_000_000;
         RateLimiter {
-            available_tokens: 0.0,
-            tokens_per_second,
-            last_update: Instant::now(),
+            available_bytes: 0,
+            bytes_per_second: bps_target,
+            last_update: now,
         }
     }
 
-    pub(crate) fn block_until_available(&mut self) {
-        if self.tokens_per_second == 0.0 {
-            return;
-        }
-
-        let now = Instant::now();
+    pub fn bytes_available(&self, now: Instant) -> u64 {
         let elapsed = now - self.last_update;
-        self.available_tokens += elapsed.as_secs_f32() * self.tokens_per_second;
-        self.available_tokens = self.available_tokens.min(self.tokens_per_second);
+        let new_bytes = elapsed.as_secs_f32() * self.bytes_per_second as f32;
+        std::cmp::min(
+            self.available_bytes + new_bytes as u64,
+            self.bytes_per_second,
+        )
+    }
 
-        if self.available_tokens < 1.0 {
-            let wait_time =
-                Duration::from_secs_f32((1.0 - self.available_tokens) / self.tokens_per_second);
-            sleep(wait_time);
-            self.available_tokens = 1.0;
+    pub fn consume_bytes(&mut self, now: Instant, amount: u64) {
+        let elapsed = now - self.last_update;
+        let new_bytes = (elapsed.as_secs_f32() * self.bytes_per_second as f32) as u64;
+        self.available_bytes += new_bytes;
+        self.available_bytes = std::cmp::min(self.available_bytes, self.bytes_per_second);
+        self.available_bytes -= amount;
+        self.last_update = now;
+    }
+
+    pub fn time_until_bytes_available(&self, now: Instant, amount: u64) -> Duration {
+        let elapsed = now - self.last_update;
+        let new_bytes = (elapsed.as_secs_f32() * self.bytes_per_second as f32) as u64;
+        let total_bytes = self.available_bytes + new_bytes;
+        if self.available_bytes + new_bytes > amount {
+            return Duration::from_secs(0);
         }
 
-        self.available_tokens -= 1.0;
-        self.last_update = Instant::now();
+        let needed = amount - total_bytes;
+        Duration::from_secs_f32(needed as f32 / self.bytes_per_second as f32)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_initial_state() {
+        let start = Instant::now();
+        let rl = RateLimiter::new(10, start);
+
+        assert_eq!(rl.bytes_available(start), 0);
+        assert_eq!(rl.bytes_per_second, 10_000_000);
+    }
+
+    #[test]
+    fn test_bytes_available_after_one_second() {
+        let start = Instant::now();
+        let rl = RateLimiter::new(10, start);
+
+        let now = start + Duration::from_secs(1);
+        assert_eq!(rl.bytes_available(now), 10_000_000);
+    }
+
+    #[test]
+    fn test_consume_bytes() {
+        let start = Instant::now();
+        let mut rl = RateLimiter::new(10, start);
+
+        let now = start + Duration::from_secs(1);
+        assert_eq!(rl.bytes_available(now), 10_000_000);
+        rl.consume_bytes(now, 4_000_000);
+        assert_eq!(rl.available_bytes, 6_000_000);
+    }
+
+    #[test]
+    fn test_bytes_available_capped_at_max() {
+        let start = Instant::now();
+        let mut rl = RateLimiter::new(10, start);
+
+        let now = start + Duration::from_secs(1);
+        rl.consume_bytes(now, 5_000_000);
+
+        let now = now + Duration::from_millis(500); // 0.5 seconds later
+        assert_eq!(rl.bytes_available(now), 10_000_000); // Should be capped at max
+
+        let now = now + Duration::from_millis(500); // 0.5 seconds later
+        assert_eq!(rl.bytes_available(now), 10_000_000); // Should be capped at max
+    }
+
+    #[test]
+    fn test_time_until_bytes_available() {
+        let start = Instant::now();
+        let mut rl = RateLimiter::new(10, start);
+
+        let now = start + Duration::from_secs(1);
+        rl.consume_bytes(now, 9_000_000);
+        assert_eq!(rl.available_bytes, 1_000_000);
+
+        let wait_time = rl.time_until_bytes_available(now, 9_000_000);
+        // at 10MB/s, 800ms for 800KB
+        assert!(wait_time > Duration::from_millis(799) && wait_time < Duration::from_millis(801));
+    }
+
+    #[test]
+    fn test_immediate_availability() {
+        let start = Instant::now();
+        let mut rl = RateLimiter::new(10, start);
+
+        let now = start + Duration::from_secs(1);
+        rl.consume_bytes(now, 9_000_000);
+
+        assert_eq!(
+            rl.time_until_bytes_available(now, 1_000_000),
+            Duration::from_secs(0)
+        );
+    }
+
+    #[test]
+    fn test_long_wait_time() {
+        let start = Instant::now();
+        let mut rl = RateLimiter::new(10, start);
+
+        let now = start + Duration::from_secs(1);
+        rl.consume_bytes(now, 9_000_000);
+
+        // this is not true, there will never be 20M available in the bucket.
+        // not sure if this case should throw when asking for > bps
+        let wait_time = rl.time_until_bytes_available(now, 20_000_000);
+        assert!(wait_time > Duration::from_secs(1) && wait_time < Duration::from_millis(2001));
     }
 }

--- a/src/ratelimiter.rs
+++ b/src/ratelimiter.rs
@@ -1,0 +1,45 @@
+use std::thread::sleep;
+use std::time::{Duration, Instant};
+
+#[derive(Debug)]
+pub struct RateLimiter {
+    available_tokens: f32,
+    tokens_per_second: f32,
+    last_update: Instant,
+}
+
+impl RateLimiter {
+    pub(crate) fn new(chunk_size_bytes: u64, mbps_target: Option<u64>) -> Self {
+        let bps_target = mbps_target.map(|x| x * 1_000_000);
+        let tokens_per_second = match bps_target {
+            None => 1.0,
+            Some(bps) => bps as f32 / chunk_size_bytes as f32,
+        };
+        RateLimiter {
+            available_tokens: 0.0,
+            tokens_per_second,
+            last_update: Instant::now(),
+        }
+    }
+
+    pub(crate) fn block_until_available(&mut self) {
+        if self.tokens_per_second == 0.0 {
+            return;
+        }
+
+        let now = Instant::now();
+        let elapsed = now - self.last_update;
+        self.available_tokens += elapsed.as_secs_f32() * self.tokens_per_second;
+        self.available_tokens = self.available_tokens.min(self.tokens_per_second);
+
+        if self.available_tokens < 1.0 {
+            let wait_time =
+                Duration::from_secs_f32((1.0 - self.available_tokens) / self.tokens_per_second);
+            sleep(wait_time);
+            self.available_tokens = 1.0;
+        }
+
+        self.available_tokens -= 1.0;
+        self.last_update = Instant::now();
+    }
+}

--- a/src/ratelimiter.rs
+++ b/src/ratelimiter.rs
@@ -12,7 +12,7 @@ impl RateLimiter {
     pub(crate) fn new(chunk_size_bytes: u64, mbps_target: Option<u64>) -> Self {
         let bps_target = mbps_target.map(|x| x * 1_000_000);
         let tokens_per_second = match bps_target {
-            None => 1.0,
+            None => 0.0,
             Some(bps) => bps as f32 / chunk_size_bytes as f32,
         };
         RateLimiter {

--- a/src/ratelimiter.rs
+++ b/src/ratelimiter.rs
@@ -11,7 +11,7 @@ impl RateLimiter {
     pub fn new(mbps_target: u64, now: Instant) -> Self {
         let bps_target = mbps_target * 1_000_000;
         RateLimiter {
-            available_bytes: 0,
+            available_bytes: bps_target,
             bytes_per_second: bps_target,
             last_update: now,
         }
@@ -57,8 +57,8 @@ mod tests {
         let start = Instant::now();
         let rl = RateLimiter::new(10, start);
 
-        assert_eq!(rl.bytes_available(start), 0);
         assert_eq!(rl.bytes_per_second, 10_000_000);
+        assert_eq!(rl.bytes_available(start), rl.bytes_per_second);
     }
 
     #[test]


### PR DESCRIPTION
This change closes #1.

Implement sender-side throttling by keeping a sliding window of all transfers that happened within the last 1 second.

Considering only the last second will keep a tighter bound on the used bandwidth, but may be problematic for high latency connections. The sliding window could be configurable, if valuable.

Should I add some integration tests for this functionality?


Sending 100MB with `--max-bandwidth 20` to localhost

```
[104595456 / 104857600]  99.8% 19.82 MB/s, 0.0 minutes left
SEND-CHUNK ChunkHeader { file_id: FileId(0), offset: 104595456, len: 262144 } header_len=14
Accepted connection from 127.0.0.1:60082.
```

Sending 100MB with `--max-bandwidth 10` to localhost
```
[104595456 / 104857600]  99.8% 9.94 MB/s, 0.0 minutes left
SEND-CHUNK ChunkHeader { file_id: FileId(0), offset: 104595456, len: 262144 } header_len=14
Accepted connection from 127.0.0.1:48560.
```

without passing `--max-bandwidth`, still to localhost

```
[104595456 / 104857600]  99.8% 2127.13 MB/s, 0.0 minutes left
SEND-CHUNK ChunkHeader { file_id: FileId(0), offset: 104595456, len: 262144 } header_len=14
```