### PR TITLE
Bump version to 1.0.0, add a changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+Fastsync follows a `MAJOR.MINOR.PATCH` versioning scheme.
+
+ * The `MAJOR` version is purely cosmetic.
+ * The `MINOR` version will be bumped for new features.
+ * The `PATCH` version will be bumped for bugfixes.
+
+Changes with compatibility impact will be marked as such in the changelog.
+There is no compatibility guarantee of the wire protocol between different
+versions, even if they differ only in `PATCH`.
+
+## 1.0.0
+
+Released 2024-09-09.
+
+ * Initial tag; various revisions of Fastsync have been in use at Chorus One
+   since February 2024.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,7 +68,7 @@ checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "fastsync"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "borsh",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fastsync"
 authors = ["Chorus One <techops@chorus.one>"]
-version = "0.1.0"
+version = "1.0.0"
 license = "Apache-2.0"
 edition = "2021"
 publish = false


### PR DESCRIPTION
We're going to deploy this internally to all machines, and having a version number and Git tag makes that easier. (I didn’t add a tag yet, I can do that if this looks good to you @yannickhilber.)