### PR TITLE
Make it print version with --version

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -181,6 +181,7 @@ fn cli() -> OptionParser<Command> {
     construct!([send_parser, recv_parser])
         .to_options()
         .descr("Fastsync -- Transfer files over multiple TCP streams")
+        .version(env!("CARGO_PKG_VERSION"))
 }
 
 fn main() {


### PR DESCRIPTION
I want to make a new release, but if we need to update it fleet-wide, it would be useful to see which version you're using from the binary itself. Let's add `--version`. Bpaf already has a feature to support this, so it's easy to integrate.